### PR TITLE
Fix long string size offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ filedir = '/path/to/test.apk'
 apk = APKParser(filedir=filedir)
 
 with open('/path/to/test.apk', 'rb') as fileobj:
-    apk = APKParser(fileobj=fileobj)
+    apk = APKParser(fileobj=fileobj.read())
 ```
 
 ### Load AAB file from object and filename

--- a/dexparser/__init__.py
+++ b/dexparser/__init__.py
@@ -93,8 +93,8 @@ class Dexparser(object):
 
         for i in range(self.header_data['string_ids_size']):
             offset = struct.unpack('<L', self.data[string_ids_off+(i*4):string_ids_off+(i*4)+4])[0]
-            c_size = self.data[offset]
-            c_char = self.data[offset+1:offset+1+c_size]
+            c_size, size_offset = uleb128_value(self.data, offset)
+            c_char = self.data[offset+size_offset:offset+size_offset+c_size]
             strings.append(c_char)
 
         return strings


### PR DESCRIPTION
For strings, the string length is actually `uleb128`.
![image](https://user-images.githubusercontent.com/17663689/225231058-82e89a87-c274-4bf5-94a0-d2ec8b89e503.png)
